### PR TITLE
Fix LightGBM CV API usage

### DIFF
--- a/optgbm/sklearn.py
+++ b/optgbm/sklearn.py
@@ -144,12 +144,14 @@ class _Objective(object):
         params = self._get_params(trial)  # type: Dict[str, Any]
         dataset = copy.copy(self.dataset)
         callbacks = self._get_callbacks(trial)  # type: List[Callable]
+        if self.fobj is not None:
+            params["fobj"] = self.fobj
+        if self.feval is not None:
+            params["feval"] = self.feval
         eval_hist = lgb.cv(
             params,
             dataset,
             callbacks=callbacks,
-            feval=self.feval,
-            fobj=self.fobj,
             folds=self.cv,
             init_model=self.init_model,
             num_boost_round=self.n_estimators,


### PR DESCRIPTION
## Summary
- adapt to LightGBM 4.0 cv() signature
- add custom objective/metric directly in params

## Testing
- `pytest -q` *(fails: `load_boston` dataset missing in sklearn 1.7)*

------
https://chatgpt.com/codex/tasks/task_e_686c480b976483289bffedd5399a3cde