### PR TITLE
Fix pruning metric in callback

### DIFF
--- a/optgbm/sklearn.py
+++ b/optgbm/sklearn.py
@@ -197,7 +197,8 @@ class _Objective(object):
 
         if self.enable_pruning:
             pruning_callback = integration.LightGBMPruningCallback(
-                trial, self.eval_name
+                trial,
+                "{}-mean".format(self.eval_name),
             )  # type: integration.LightGBMPruningCallback
 
             callbacks.append(pruning_callback)


### PR DESCRIPTION
## Summary
- monitor aggregated mean metric for pruning

## Testing
- `black optgbm/sklearn.py --line-length 79`

------
https://chatgpt.com/codex/tasks/task_e_686c4c6f22788328ad8583cc688511b1