### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ By default, the following hyperparameters will be searched.
 
 - `bagging_fraction`
 - `bagging_freq`
-- `feature_fractrion`
+- `feature_fraction`
 - `lambda_l1`
 - `lambda_l2`
 - `max_depth`


### PR DESCRIPTION
## Summary
- update `feature_fractrion` typo in README

## Testing
- `pre-commit run --files README.md` *(fails: requires network access)*
- `pytest -q` *(fails: missing plugins)*

------
https://chatgpt.com/codex/tasks/task_e_686c4d69464483289ef779c6327323fa