### PR TITLE
Update Python versions and CI

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.8, 3.9, 3.10, 3.11]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 OptGBM (= [Optuna](https://optuna.org/) + [LightGBM](http://github.com/microsoft/LightGBM)) provides a scikit-learn compatible estimator that tunes hyperparameters in LightGBM with Optuna.
 
+This package requires Python 3.8 or newer.
+
 ## Examples
 
 ```python

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,13 @@ license = MIT License
 long_description = file: README.md
 long_description_content_type = text/markdown
 name = OptGBM
+classifiers =
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 
 [mypy]
 disallow_untyped_defs = True
@@ -24,7 +31,7 @@ install_requires =
   pandas
   scikit-learn>=0.19.0
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.8
 setup_requires =
   setuptools_scm
 


### PR DESCRIPTION
## Summary
- set `python_requires` to `>=3.8`
- update CI matrix to run on Python 3.8–3.11
- document requirement for Python 3.8+
- add classifiers for supported Python versions

## Testing
- `pip install -e .[testing]`
- `pytest -q -o addopts=""` *(fails: ModuleNotFoundError for pkg_resources and dataset issue)*
- `tox -q` *(fails: No matching distribution for types-pkg-resources)*

------
https://chatgpt.com/codex/tasks/task_e_686c4c9b9f088328b9fb983604b228f2