### PR TITLE
Replace deprecated Boston dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ OptGBM (= [Optuna](https://optuna.org/) + [LightGBM](http://github.com/microsoft
 
 ```python
 import optgbm as lgb
-from sklearn.datasets import load_boston
+from sklearn.datasets import load_diabetes
 
 reg = lgb.LGBMRegressor(random_state=0)
-X, y = load_boston(return_X_y=True)
+X, y = load_diabetes(return_X_y=True)
 
 reg.fit(X, y)
 

--- a/optgbm/sklearn.py
+++ b/optgbm/sklearn.py
@@ -1196,10 +1196,10 @@ class LGBMRegressor(LGBMModel, RegressorMixin):
     Examples
     --------
     >>> import optgbm as lgb
-    >>> from sklearn.datasets import load_boston
+    >>> from sklearn.datasets import load_diabetes
     >>> tmp_path = getfixture("tmp_path")  # noqa
     >>> reg = lgb.LGBMRegressor(random_state=0, model_dir=tmp_path)
-    >>> X, y = load_boston(return_X_y=True)
+    >>> X, y = load_diabetes(return_X_y=True)
     >>> reg.fit(X, y)
     LGBMRegressor(...)
     >>> y_pred = reg.predict(X)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,20 +1,20 @@
 import numpy as np
 
-from sklearn.datasets import load_boston
+from sklearn.datasets import load_diabetes
 
 from optgbm.utils import check_fit_params
 from optgbm.utils import check_X
 
 
 def test_check_X() -> None:
-    X, _ = load_boston(return_X_y=True)
+    X, _ = load_diabetes(return_X_y=True)
     X = check_X(X)
 
     assert isinstance(X, np.ndarray)
 
 
 def test_check_fit_params() -> None:
-    X, y = load_boston(return_X_y=True)
+    X, y = load_diabetes(return_X_y=True)
     X, y, sample_weight = check_fit_params(X, y)
 
     assert isinstance(X, np.ndarray)


### PR DESCRIPTION
## Summary
- switch examples and tests from `load_boston` to `load_diabetes`

## Testing
- `pytest -q` *(fails: KeyError: 'binary_logloss-mean')*

------
https://chatgpt.com/codex/tasks/task_e_686c4c9366888328857caf4bc7c2fdd9