### PR TITLE
Simplify booster extraction

### DIFF
--- a/optgbm/typing.py
+++ b/optgbm/typing.py
@@ -13,7 +13,7 @@ import pandas as pd
 from scipy.sparse import spmatrix
 from sklearn.model_selection import BaseCrossValidator
 
-from lightgbm.engine import CVBooster
+from lightgbm import CVBooster
 
 CVType = Union[BaseCrossValidator, int, List[Tuple]]
 


### PR DESCRIPTION
## Summary
- import `safe_indexing` compatibly for new scikit-learn
- remove custom LightGBM extraction callback
- get CV boosters directly via `lgb.cv(..., return_cvbooster=True)`
- adjust typing import for `CVBooster`

## Testing
- `pytest -q -c /dev/null` *(fails: train() got an unexpected keyword argument 'fobj')*

------
https://chatgpt.com/codex/tasks/task_e_686c853426d083289967caa9024e8af8