### PR TITLE
Improve custom metric direction handling and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,34 @@ By default, the following hyperparameters will be searched.
 - `min_data_in_leaf`
 - `num_leaves`
 
+## Customizing the Search Space
+
+You can take full control of the hyperparameter search by passing a
+`param_distributions` dictionary to the estimator. The values should be Optuna
+distribution objects.
+
+```python
+import optgbm as lgb
+from optuna.distributions import IntDistribution, FloatDistribution
+from sklearn.datasets import load_breast_cancer
+
+# Define a custom search space
+param_distributions = {
+    "num_leaves": IntDistribution(20, 100),
+    "learning_rate": FloatDistribution(0.01, 0.2, log=True),
+    "lambda_l1": FloatDistribution(1e-8, 1.0, log=True),
+}
+
+clf = lgb.LGBMClassifier(
+    param_distributions=param_distributions,
+    n_trials=50,  # Search more trials for the custom space
+    random_state=42,
+)
+
+X, y = load_breast_cancer(return_X_y=True)
+clf.fit(X, y)
+```
+
 ## Installation
 
 ```

--- a/optgbm/__init__.py
+++ b/optgbm/__init__.py
@@ -12,13 +12,26 @@ try:
 except Exception:  # pragma: no cover
     pass
 
-from lightgbm import *  # noqa
 
 from . import basic  # noqa
-from . import sklearn  # noqa
+from . import sklearn as _sklearn_module  # noqa: F401
 from . import typing  # noqa
 from . import utils  # noqa
-from .sklearn import *  # noqa
+from .sklearn import (
+    LGBMModel,
+    LGBMClassifier,
+    LGBMRegressor,
+    OGBMClassifier,
+    OGBMRegressor,
+)
+
+__all__ = [
+    "LGBMModel",
+    "LGBMClassifier",
+    "LGBMRegressor",
+    "OGBMClassifier",
+    "OGBMRegressor",
+]
 
 logger = logging.getLogger(__name__)
 handler = logging.StreamHandler()

--- a/optgbm/utils.py
+++ b/optgbm/utils.py
@@ -15,8 +15,6 @@ from sklearn.utils import check_array
 from sklearn.utils import check_consistent_length
 from sklearn.utils.class_weight import compute_sample_weight
 from sklearn.utils.multiclass import check_classification_targets
-from sklearn.utils.validation import _assert_all_finite
-from sklearn.utils.validation import _num_samples
 from sklearn.utils.validation import column_or_1d
 
 from .typing import CVType
@@ -135,13 +133,13 @@ def check_fit_params(
     if not isinstance(y, pd.Series):
         y = column_or_1d(y, warn=True)
 
-    _assert_all_finite(y)
+    y = check_array(y, ensure_2d=False, dtype=None)
 
     if is_classifier(estimator):
         check_classification_targets(y)
 
     if sample_weight is None:
-        n_samples = _num_samples(X)
+        n_samples = len(X)
         sample_weight = np.ones(n_samples)
 
     sample_weight = np.asarray(sample_weight)

--- a/tests/test_sklearn.py
+++ b/tests/test_sklearn.py
@@ -256,13 +256,18 @@ def test_fit_with_fit_params(
         n_estimators=n_estimators, n_trials=n_trials, model_dir=tmp_path
     )
 
-    clf.fit(
-        X,
-        y,
-        callbacks=callbacks,
-        eval_metric=eval_metric,
-        optuna_callbacks=optuna_callbacks,
-    )
+    fit_kwargs = {
+        "X": X,
+        "y": y,
+        "callbacks": callbacks,
+        "eval_metric": eval_metric,
+        "optuna_callbacks": optuna_callbacks,
+    }
+
+    if callable(eval_metric):
+        fit_kwargs["eval_direction"] = "minimize"
+
+    clf.fit(**fit_kwargs)
 
 
 def test_fit_with_unused_fit_params(tmp_path: pathlib.Path) -> None:


### PR DESCRIPTION
## Summary
- update eval metric direction handling in `LGBMModel.fit`
- expand list of higher-is-better metrics
- use temp dir when `model_dir` is not provided
- add example of `param_distributions` in README
- avoid unused imports and update utils
- adjust tests for new `eval_direction`

## Testing
- `pip install pytest pytest-black pytest-cov pytest-flake8 pytest-mypy pytest-pydocstyle lightgbm numpy pandas scikit-learn optuna natsort` *(fails: tests report numerous mypy/flake8 errors)*
- `pytest -q` *(fails: 62 failed, 14 passed, 18 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_686c853beb108328bc989a7fbda23e8d