### PR TITLE
Improve custom metric handling and default model dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,32 @@ By default, the following hyperparameters will be searched.
 - `min_data_in_leaf`
 - `num_leaves`
 
+## Customizing the Search Space
+
+You can take full control of the hyperparameter search by passing a `param_distributions` dictionary to the estimator. The values should be Optuna distribution objects.
+
+```python
+import optgbm as lgb
+from optuna.distributions import IntDistribution, FloatDistribution
+from sklearn.datasets import load_breast_cancer
+
+# Define a custom search space
+param_distributions = {
+    "num_leaves": IntDistribution(20, 100),
+    "learning_rate": FloatDistribution(0.01, 0.2, log=True),
+    "lambda_l1": FloatDistribution(1e-8, 1.0, log=True),
+}
+
+clf = lgb.LGBMClassifier(
+    param_distributions=param_distributions,
+    n_trials=50,  # Search more trials for the custom space
+    random_state=42,
+)
+
+X, y = load_breast_cancer(return_X_y=True)
+clf.fit(X, y)
+```
+
 ## Installation
 
 ```

--- a/optgbm/__init__.py
+++ b/optgbm/__init__.py
@@ -12,13 +12,28 @@ try:
 except Exception:  # pragma: no cover
     pass
 
-from lightgbm import *  # noqa
+import lightgbm
 
 from . import basic  # noqa
-from . import sklearn  # noqa
+from . import sklearn as sklearn_module  # noqa
 from . import typing  # noqa
 from . import utils  # noqa
-from .sklearn import *  # noqa
+
+from .sklearn import (
+    LGBMModel,
+    LGBMClassifier,
+    LGBMRegressor,
+    OGBMClassifier,
+    OGBMRegressor,
+)
+
+__all__ = [
+    "LGBMModel",
+    "LGBMClassifier",
+    "LGBMRegressor",
+    "OGBMClassifier",
+    "OGBMRegressor",
+]
 
 logger = logging.getLogger(__name__)
 handler = logging.StreamHandler()

--- a/optgbm/utils.py
+++ b/optgbm/utils.py
@@ -15,8 +15,6 @@ from sklearn.utils import check_array
 from sklearn.utils import check_consistent_length
 from sklearn.utils.class_weight import compute_sample_weight
 from sklearn.utils.multiclass import check_classification_targets
-from sklearn.utils.validation import _assert_all_finite
-from sklearn.utils.validation import _num_samples
 from sklearn.utils.validation import column_or_1d
 
 from .typing import CVType
@@ -135,13 +133,13 @@ def check_fit_params(
     if not isinstance(y, pd.Series):
         y = column_or_1d(y, warn=True)
 
-    _assert_all_finite(y)
+    y = check_array(y, ensure_2d=False, dtype=None)
 
     if is_classifier(estimator):
         check_classification_targets(y)
 
     if sample_weight is None:
-        n_samples = _num_samples(X)
+        n_samples = len(X)
         sample_weight = np.ones(n_samples)
 
     sample_weight = np.asarray(sample_weight)

--- a/tests/test_sklearn.py
+++ b/tests/test_sklearn.py
@@ -261,6 +261,7 @@ def test_fit_with_fit_params(
         y,
         callbacks=callbacks,
         eval_metric=eval_metric,
+        eval_direction="minimize" if callable(eval_metric) else None,
         optuna_callbacks=optuna_callbacks,
     )
 


### PR DESCRIPTION
## Summary
- expand `_is_higher_better` for more metrics
- add `eval_direction` parameter for custom metrics
- use a temporary folder when `model_dir` is not provided
- avoid private sklearn utils in `check_fit_params`
- expose public API in `__init__`
- document custom parameter search space
- update tests for new parameter

## Testing
- `pytest -q -o addopts=''` *(fails: TypeError: train() got an unexpected keyword argument 'fobj')*

------
https://chatgpt.com/codex/tasks/task_e_686c87655c588328a2d8c32d1b11f3c3