### PR TITLE
Fix dataset param duplication

### DIFF
--- a/optgbm/sklearn.py
+++ b/optgbm/sklearn.py
@@ -370,10 +370,8 @@ class LGBMModel(lgb.LGBMModel):
             if fobj is not None:
                 train_params['objective'] = fobj
 
-            # Add feature_name and categorical_feature to the params dictionary
-            # The 'auto' default is handled by LightGBM, so we can pass it directly.
-            train_params['feature_name'] = feature_name
-            train_params['categorical_feature'] = categorical_feature
+            # The feature_name and categorical_feature parameters are now removed.
+            # lgb.train will correctly infer this information from the 'dataset' object.
 
             booster = lgb.train(
                 train_params,


### PR DESCRIPTION
## Summary
- remove `feature_name` and `categorical_feature` from parameters passed to `lgb.train`

## Testing
- `pytest -q` *(fails: Found 42 errors in 6 files)*

------
https://chatgpt.com/codex/tasks/task_e_686d106ec35c8328a5fad35e32b1a14d