### PR TITLE
Fix README prediction usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ X, y = load_diabetes(return_X_y=True)
 
 reg.fit(X, y)
 
-y_pred = reg.predict(X, y)
+y_pred = reg.predict(X)
 ```
 
 By default, the following hyperparameters will be searched.


### PR DESCRIPTION
## Summary
- correct prediction example in README

## Testing
- `pip install -e .[testing]`
- `pytest -q` *(fails: mypy, flake8, black checks)*

------
https://chatgpt.com/codex/tasks/task_e_686d12eba4948328a9a5f12b91706d6b