### PR TITLE
Remove unused feature metadata in booster creation

### DIFF
--- a/optgbm/sklearn.py
+++ b/optgbm/sklearn.py
@@ -361,8 +361,6 @@ class LGBMModel(lgb.LGBMModel):
         best_index: int,
         weights: np.ndarray,
         fobj: Optional[Callable] = None,
-        feature_name: Union[List[str], str] = "auto",
-        categorical_feature: Union[List[int], List[str], str] = "auto",
         callbacks: Optional[List[Callable]] = None,
         init_model: Optional[Union[lgb.Booster, lgb.LGBMModel, str]] = None,
     ) -> Union[_VotingBooster, lgb.Booster]:
@@ -668,8 +666,6 @@ class LGBMModel(lgb.LGBMModel):
             self.best_index_,
             weights,
             fobj=fobj,
-            feature_name=feature_name,
-            categorical_feature=categorical_feature,
             callbacks=callbacks,
             init_model=init_model,
         )


### PR DESCRIPTION
## Summary
- clean up `_make_booster` by removing unused `feature_name` and `categorical_feature` parameters
- drop corresponding arguments when calling `_make_booster`

## Testing
- `pytest -q` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_686d194df2648328b10004c91f00e28e