### PR TITLE
Fix VotingBooster start_iteration param

### DIFF
--- a/optgbm/basic.py
+++ b/optgbm/basic.py
@@ -48,6 +48,7 @@ class _VotingBooster(object):
     def predict(
         self,
         X: TwoDimArrayLikeType,
+        start_iteration: int = 0,
         num_iteration: Optional[int] = None,
         raw_score: bool = False,
         pred_leaf: bool = False,
@@ -71,7 +72,12 @@ class _VotingBooster(object):
             logger.warning("{}={} will be ignored.".format(key, value))
 
         results = [
-            b.predict(X, num_iteration=num_iteration) for b in self._boosters
+            b.predict(
+                X,
+                start_iteration=start_iteration,
+                num_iteration=num_iteration,
+            )
+            for b in self._boosters
         ]
 
         return np.average(results, axis=0, weights=self.weights)


### PR DESCRIPTION
## Summary
- pass `start_iteration` through VotingBooster.predict

## Testing
- `pip install -e .`
- `pytest -q` *(fails: 34 failed, 60 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686d1fd788808328a9db226e3c1ad254