### PR TITLE
Fix default n_jobs parameter

### DIFF
--- a/optgbm/sklearn.py
+++ b/optgbm/sklearn.py
@@ -279,7 +279,7 @@ class LGBMModel(lgb.LGBMModel):
         reg_alpha: float = 0.0,
         reg_lambda: float = 0.0,
         random_state: Optional[RandomStateType] = None,
-        n_jobs: int = -1,
+        n_jobs: Optional[int] = None,
         verbose: int = -1,
         importance_type: str = "split",
         cv: CVType = 5,
@@ -785,7 +785,7 @@ class LGBMClassifier(LGBMModel, ClassifierMixin):
         state from `numpy.random` is used.
 
     n_jobs
-        Number of parallel jobs. -1 means using all processors.
+        Number of parallel jobs. ``None`` lets LightGBM use all available cores.
 
     verbose
         Controls the level of LightGBM's verbosity. ``-1`` means silent.
@@ -1104,7 +1104,7 @@ class LGBMRegressor(LGBMModel, RegressorMixin):
         state from `numpy.random` is used.
 
     n_jobs
-        Number of parallel jobs. -1 means using all processors.
+        Number of parallel jobs. ``None`` lets LightGBM use all available cores.
 
     verbose
         Controls the level of LightGBM's verbosity. ``-1`` means silent.


### PR DESCRIPTION
## Summary
- update `n_jobs` default in `LGBMModel`
- document that `None` uses all available cores

## Testing
- `pytest -q -c /dev/null` *(fails: AssertionError: Estimator should raise a NotFittedError ...)*

------
https://chatgpt.com/codex/tasks/task_e_686d1ffff8d88328962b0ecc35544ebb