### PR TITLE
Fix feval argument passing

### DIFF
--- a/optgbm/sklearn.py
+++ b/optgbm/sklearn.py
@@ -144,8 +144,6 @@ class _Objective(object):
         callbacks = self._get_callbacks(trial)  # type: List[Callable]
         if self.fobj is not None:
             params["objective"] = self.fobj
-        if self.feval is not None:
-            params["feval"] = self.feval
         eval_hist = lgb.cv(
             params,
             dataset,
@@ -153,6 +151,7 @@ class _Objective(object):
             folds=self.cv,
             init_model=self.init_model,
             num_boost_round=self.n_estimators,
+            feval=self.feval,
             return_cvbooster=True,
         )  # Dict[str, Any]
         # Note: The validation set in lgb.cv is named "valid" by default.
@@ -361,6 +360,7 @@ class LGBMModel(lgb.LGBMModel):
         best_index: int,
         weights: np.ndarray,
         fobj: Optional[Callable] = None,
+        feval: Optional[Callable] = None,
         callbacks: Optional[List[Callable]] = None,
         init_model: Optional[Union[lgb.Booster, lgb.LGBMModel, str]] = None,
     ) -> Union[_VotingBooster, lgb.Booster]:
@@ -378,6 +378,7 @@ class LGBMModel(lgb.LGBMModel):
                 num_boost_round=num_boost_round,
                 callbacks=callbacks,
                 init_model=init_model,
+                feval=feval,
             )
 
             booster.free_dataset()
@@ -689,6 +690,7 @@ class LGBMModel(lgb.LGBMModel):
             self.best_index_,
             weights,
             fobj=fobj,
+            feval=feval,
             callbacks=callbacks,
             init_model=init_model,
         )


### PR DESCRIPTION
## Summary
- ensure custom evaluation metric is passed correctly to `lgb.cv`
- propagate `feval` into `_make_booster` for refitting

## Testing
- `pip install -e .`
- `pytest -q` *(fails: mypy, style and unit tests)*

------
https://chatgpt.com/codex/tasks/task_e_686d20913a608328ab954f2d59e9859e