### PR TITLE
Fix ensure_all_finite parameter name

### DIFF
--- a/optgbm/sklearn.py
+++ b/optgbm/sklearn.py
@@ -534,7 +534,7 @@ class LGBMModel(lgb.LGBMModel):
             accept_sparse=True,
             ensure_min_samples=2,
             estimator=self,
-            ensure_all_finite=False,
+            force_all_finite=False,
         )
 
         # See https://github.com/microsoft/LightGBM/issues/2319


### PR DESCRIPTION
## Summary
- fix wrong parameter name passed to `check_fit_params`

## Testing
- `pytest -q -o addopts=''` *(fails: 53 failed, 4 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686d2eaeef1c8328a43f5b7aeec17bba