### PR TITLE
Fix utils check_X and pruning callback

### DIFF
--- a/optgbm/sklearn.py
+++ b/optgbm/sklearn.py
@@ -198,11 +198,16 @@ class _Objective(object):
             # suffix and specify the validation dataset name used by
             # ``lgb.cv``.  LightGBMPruningCallback expects these parameters to
             # match the intermediate results reported during training.
-            pruning_callback = integration.LightGBMPruningCallback(
-                trial,
-                metric=self.eval_name,
-                valid_name="valid",
-            )  # type: integration.LightGBMPruningCallback
+            try:
+                # For Optuna >= 3.6
+                pruning_callback = integration.LightGBMPruningCallback(
+                    trial, metric=self.eval_name, valid_name="valid"
+                )
+            except TypeError:
+                # Fallback for Optuna < 3.6
+                pruning_callback = integration.LightGBMPruningCallback(
+                    trial, metric=self.eval_name
+                )
 
             callbacks.append(pruning_callback)
 
@@ -571,7 +576,7 @@ class LGBMModel(lgb.LGBMModel):
             sample_weight=sample_weight,
             accept_sparse=True,
             ensure_min_samples=2,
-            estimator=None,
+            estimator=self,
             force_all_finite=False,
         )
 

--- a/optgbm/utils.py
+++ b/optgbm/utils.py
@@ -79,7 +79,7 @@ def check_X(
         X = check_array(X, estimator=estimator, **kwargs)
 
     _, actual_n_features = X.shape
-    expected_n_features = getattr(estimator, "n_features_", actual_n_features)
+    expected_n_features = getattr(estimator, "_n_features", actual_n_features)
 
     if actual_n_features != expected_n_features:
         raise ValueError(


### PR DESCRIPTION
## Summary
- handle `_n_features` check in `check_X`
- restore `self` validation in `check_fit_params`
- add optuna version compatibility for pruning callback

## Testing
- `pip install -e .`
- `pytest -q` *(fails: mypy, flake8, black, pydocstyle checks, and multiple test cases)*

------
https://chatgpt.com/codex/tasks/task_e_686d4942674883289479efc4acf84260