### PR TITLE
Remove invalid best_iteration_ assignment

### DIFF
--- a/optgbm/sklearn.py
+++ b/optgbm/sklearn.py
@@ -712,8 +712,10 @@ class LGBMModel(lgb.LGBMModel):
 
         best_iteration = self.study_.best_trial.user_attrs["best_iteration"]
 
+        # LightGBM's LGBMModel already exposes read-only property best_iteration_
+        # that returns self._best_iteration, so we only need to populate the
+        # private attribute.
         self._best_iteration = None if early_stopping_rounds is None else best_iteration
-        self.best_iteration_ = self._best_iteration
         self._best_score = self.study_.best_value
         self._objective = params["objective"]
         self.best_params_ = {**params, **self.study_.best_params}


### PR DESCRIPTION
## Summary
- fix AttributeError by no longer setting read-only `best_iteration_`

## Testing
- `pytest -q` *(fails: 72 failed, 5 passed, 13 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_686d51abd0e483288b5984c8fd63b01b